### PR TITLE
[#2] Reduce lifetime of certificate to 46 days if origin server certificate is unknown

### DIFF
--- a/src/ssl/gadgets.cc
+++ b/src/ssl/gadgets.cc
@@ -586,7 +586,7 @@ static bool buildCertificate(Security::CertPointer & cert, Ssl::CertificatePrope
     ASN1_TIME *aTime = nullptr;
     if (!properties.setValidBefore && properties.mimicCert.get())
         aTime = X509_getm_notBefore(properties.mimicCert.get());
-    if (!aTime && properties.signWithX509.get())
+    if (!aTime && properties.setValidBefore && properties.signWithX509.get())
         aTime = X509_getm_notBefore(properties.signWithX509.get());
 
     if (aTime) {
@@ -598,12 +598,13 @@ static bool buildCertificate(Security::CertPointer & cert, Ssl::CertificatePrope
     aTime = nullptr;
     if (!properties.setValidAfter && properties.mimicCert.get())
         aTime = X509_getm_notAfter(properties.mimicCert.get());
-    if (!aTime && properties.signWithX509.get())
+    if (!aTime && properties.setValidAfter && properties.signWithX509.get())
         aTime = X509_getm_notAfter(properties.signWithX509.get());
+
     if (aTime) {
         if (!X509_set1_notAfter(cert.get(), aTime))
             return false;
-    } else if (!X509_gmtime_adj(X509_getm_notAfter(cert.get()), 60*60*24*365*3))
+    } else if (!X509_gmtime_adj(X509_getm_notAfter(cert.get()), 44*24*60*60))
         return false;
 
     int addedExtensions = 0;


### PR DESCRIPTION
Starting 15 March, 2029 a TLS certificate may not have a lifetime of more than 47 days (see CA/Browser Forum baseline requirements).
Only if the properties setNotBefore and setNotAfter are defined, the CA's lifetime is used. If the origin server certificate is known, its lifetime is used.